### PR TITLE
Clear armor stand equipments when open gui.

### DIFF
--- a/plugin/src/main/java/de/rapha149/armorstandeditor/Config.java
+++ b/plugin/src/main/java/de/rapha149/armorstandeditor/Config.java
@@ -34,6 +34,10 @@ public class Config {
                                  "\nIf you want a feature to be enabled and everybody to be able to use it, set the permission to \"null\".");
         comments.put("features.replaceEquipment", "Replacing the armor stand's equipment (armor and hand items) in the ASE inventory.");
         comments.put("features.replaceEquipment.useDeactivatedItem", "Whether or not to replace the armor and hand items of the armor stand with the disabled item when this feature is disabled.");
+        comments.put("features.replaceEquipment.clearItemsOnOpen", """
+                Whether or not to clear the armor stand's equipment when the gui is opened. This will prevent duplication bugs that players can cause using mods.
+                If you're running a small server with friends, you can choose to disable this option if you don't want the equipment to vanish every time you open the gui.
+                However, if you're running a server with a few more players, it is recommended to leave this option enabled.""");
         comments.put("features.moveBodyParts", "Moving the armor stand's body parts.");
         comments.put("features.movePosition", "Moving the armor stand's position.");
         comments.put("features.rotate", "Changing the armor stand's rotation.");
@@ -276,6 +280,7 @@ public class Config {
         public static class ReplaceEquipmentFeatureData extends FeatureData {
 
             public boolean useDeactivatedItem = false;
+            public boolean clearItemsOnOpen = true;
         }
 
         public static class VehicleFeatureData extends FeatureData {

--- a/plugin/src/main/java/de/rapha149/armorstandeditor/Events.java
+++ b/plugin/src/main/java/de/rapha149/armorstandeditor/Events.java
@@ -35,7 +35,7 @@ import org.bukkit.event.inventory.InventoryType.SlotType;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
 import org.bukkit.event.player.*;
 import org.bukkit.inventory.CraftingInventory;
-import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
@@ -50,6 +50,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import static de.rapha149.armorstandeditor.Messages.getMessage;
+import static de.rapha149.armorstandeditor.Util.EQUIPMENT_SLOTS;
 
 public class Events implements Listener {
 
@@ -118,17 +119,11 @@ public class Events implements Listener {
         List<ItemStack> armorContents = null;
         for (ArmorStandStatus status : new HashMap<>(Util.invs).values()) {
             if (status.armorStand.getUniqueId().equals(uuid)) {
-                if (Util.saveEquipment(status)) {
-                    EntityEquipment equipment = armorStand.getEquipment();
-                    armorContents = List.of(
-                            equipment.getHelmet(),
-                            equipment.getChestplate(),
-                            equipment.getLeggings(),
-                            equipment.getBoots(),
-                            equipment.getItemInMainHand(),
-                            equipment.getItemInOffHand()
-                    );
-                    equipment.clear();
+                if (status.saveEquipment) {
+                    status.saveEquipment = false;
+                    Inventory inv = status.gui.getInventory();
+                    armorContents = EQUIPMENT_SLOTS.stream().map(slot -> Optional.ofNullable(inv.getItem(slot)).orElseGet(() -> new ItemStack(Material.AIR))).toList();
+                    armorStand.getEquipment().clear();
                 }
                 status.gui.close(status.player);
             }
@@ -139,7 +134,7 @@ public class Events implements Listener {
             boolean armorStandItem = false;
             for (Iterator<ItemStack> iterator = drops.iterator(); iterator.hasNext(); ) {
                 ItemStack item = iterator.next();
-                if(item.getType() == Material.ARMOR_STAND && !armorStandItem) {
+                if (item.getType() == Material.ARMOR_STAND && !armorStandItem) {
                     armorStandItem = true;
                     item.setAmount(1);
                 } else

--- a/plugin/src/main/java/de/rapha149/armorstandeditor/pages/ArmorPage.java
+++ b/plugin/src/main/java/de/rapha149/armorstandeditor/pages/ArmorPage.java
@@ -82,6 +82,7 @@ public class ArmorPage extends Page {
                 if (!status.saveEquipment || !EQUIPMENT_SLOTS.contains(event.getRawSlot()))
                     event.setCancelled(true);
             });
+            armorStand.getEquipment().clear();
         }
 
         gui.setItem(2, 7, checkDeactivated(applyNameAndLore(ItemBuilder.from(Material.PLAYER_HEAD), "armorstands.move_body_parts.head").asGuiItem(event -> {

--- a/plugin/src/main/java/de/rapha149/armorstandeditor/pages/ArmorPage.java
+++ b/plugin/src/main/java/de/rapha149/armorstandeditor/pages/ArmorPage.java
@@ -82,7 +82,8 @@ public class ArmorPage extends Page {
                 if (!status.saveEquipment || !EQUIPMENT_SLOTS.contains(event.getRawSlot()))
                     event.setCancelled(true);
             });
-            armorStand.getEquipment().clear();
+            if (features.replaceEquipment.clearItemsOnOpen)
+                armorStand.getEquipment().clear();
         }
 
         gui.setItem(2, 7, checkDeactivated(applyNameAndLore(ItemBuilder.from(Material.PLAYER_HEAD), "armorstands.move_body_parts.head").asGuiItem(event -> {


### PR DESCRIPTION
Since plugin will put item back when player close GUI, we can clear armor stand's equipments when open it.
This is the simplest way to fix #15 .